### PR TITLE
add route for nested round data

### DIFF
--- a/data/migrations/20190424165604_create_tables.js
+++ b/data/migrations/20190424165604_create_tables.js
@@ -111,13 +111,6 @@ exports.up = function(knex) {
           .inTable('rounds')
           .onDelete('CASCADE')
           .onUpdate('CASCADE');
-        tbl
-          .integer('user_id')
-          .unsigned()
-          .references('id')
-          .inTable('users')
-          .onDelete('CASCADE')
-          .onUpdate('CASCADE');
       })
       //Answers table
       .createTable('answers', tbl => {

--- a/data/seeds/007-questions.js
+++ b/data/seeds/007-questions.js
@@ -8,7 +8,6 @@ exports.seed = async function(knex) {
   const dbQuestionTypes = await knex('question_types');
   const dbCategories = await knex('categories');
   const dbRounds = await knex('rounds');
-  const dbUsers = await knex('users').whereNotNull('auth0_id');
 
   const questions = [];
 
@@ -17,7 +16,6 @@ exports.seed = async function(knex) {
       question_type_id: randomItem(dbQuestionTypes).id,
       category_id: randomItem(dbCategories).id,
       round_id: randomItem(dbRounds).id,
-      user_id: randomItem(dbUsers).id,
       difficulty: randomItem(['easy', 'medium', 'hard']),
       text: faker.hacker.phrase()
     });

--- a/models/games.js
+++ b/models/games.js
@@ -215,11 +215,6 @@ async function nestedInsert({ rounds: newRounds, ...newGame }) {
   }
 
   // batch insert those newQuestions, omit the answers here
-  // const createdQuestions = await db('questions')
-  //   .insert(newQuestions.map(({ answers: omit, ...q }) => q), 'id')
-  //   .then(() =>
-  //     db('questions').whereIn('round_id', createdRounds.map(r => r.id))
-  //   );
   const createdQuestions = await Promise.all(
     newQuestions.map(({ answers: omit, ...q }) =>
       db('questions')
@@ -245,7 +240,7 @@ async function nestedInsert({ rounds: newRounds, ...newGame }) {
   if (newAnswers.length === 0) {
     return createdGame.id;
   }
-  const createdAnswers = await db('answers').insert(newAnswers, 'id');
+  await db('answers').insert(newAnswers, 'id');
 
   // return the id of the createdGame
   return createdGame.id;

--- a/models/rounds.js
+++ b/models/rounds.js
@@ -151,8 +151,6 @@ async function nestedUpdate(id, nestedRound) {
     )
   );
 
-  console.log(createdQuestions);
-
   // do the same for answers
   const newAnswers = [].concat.apply(
     [],

--- a/models/rounds.js
+++ b/models/rounds.js
@@ -2,12 +2,13 @@ const db = require('../data/db');
 
 module.exports = {
   get,
-  insert,
-  getById,
-  update,
-  deleteItem,
   find,
+  insert,
+  update,
+  getById,
+  deleteItem,
   withUserId,
+  nestedUpdate,
   findWithCounts,
   findByIdNormalized
 };
@@ -117,4 +118,59 @@ async function deleteItem(id) {
   return await db('rounds')
     .where({ id })
     .del();
+}
+
+// method that deletes a round's questions and answers (via cascade)
+// and replaces them with new questions and answers
+async function nestedUpdate(id, nestedRound) {
+  const { questions: newQuestions, ...roundDetails } = nestedRound;
+  const dbRound = await db('rounds')
+    .where({ id })
+    .update(roundDetails)
+    .then(() => getById(id));
+
+  if(!newQuestions) {
+    return dbRound.id;
+  }
+
+  // delete all of this rounds questions
+  await db('questions')
+    .where({ round_id: dbRound.id })
+    .del();
+
+  // create new questions and answers
+  const createdQuestions = await Promise.all(
+    newQuestions.map(({ id: omitId, answers: omit, ...q }) =>
+      db('questions')
+        .insert({ ...q, round_id: dbRound.id }, 'id')
+        .then(ids =>
+          db('questions')
+            .where({ id: ids[0] })
+            .first()
+        )
+    )
+  );
+
+  console.log(createdQuestions);
+
+  // do the same for answers
+  const newAnswers = [].concat.apply(
+    [],
+    newQuestions.reduce((accu, q, idx) => {
+      if (q.answers) {
+        return [
+          ...accu,
+          q.answers.map(a => ({ question_id: createdQuestions[idx].id, ...a }))
+        ];
+      }
+      return accu;
+    }, [])
+  );
+
+  if (newAnswers.length === 0) {
+    return dbRound.id;
+  }
+  await db('answers').insert(newAnswers, 'id');
+
+  return dbRound.id;
 }

--- a/routes/games.js
+++ b/routes/games.js
@@ -1,4 +1,5 @@
 const router = require('express').Router();
+const diff = require('deep-diff').diff;
 
 const Games = require('../models/games');
 
@@ -108,6 +109,16 @@ router.post('/', async (req, res) => {
   newGame.user_id = req.user.dbInfo.id;
 
   const createdGame = await Games.insert(newGame);
+  return res.status(200).json(createdGame);
+});
+
+// post nested
+router.post('/nested', async (req, res) => {
+  const { body: newGame } = req;
+  newGame.user_id = req.user.dbInfo.id;
+  const newGameId = await Games.nestedInsert(newGame);
+  const createdGame = await Games.findByIdAndUserId(newGameId, newGame.user_id);
+
   return res.status(200).json(createdGame);
 });
 

--- a/routes/games.js
+++ b/routes/games.js
@@ -1,5 +1,4 @@
 const router = require('express').Router();
-const diff = require('deep-diff').diff;
 
 const Games = require('../models/games');
 

--- a/routes/rounds.js
+++ b/routes/rounds.js
@@ -10,8 +10,7 @@ router.get('/', async (req, res) => {
   if (rounds) {
     res.status(200).json(rounds);
   } else {
-    res.status(500).json({ error: 'error in retrieving round' });
-  }
+    res.status(500).json({ error: 'error in retrieving round' }); }
 });
 
 // get all user rounds, normalized
@@ -91,7 +90,7 @@ router.post('/', async (req, res) => {
 });
 
 // edit an existing round, including any changes necessary for
-// nested data
+// nested data, respond with normalized response
 router.put('/nested/:id', async (req, res) => {
   const { id } = req.params;
   const userId = req.user.dbInfo.id;


### PR DESCRIPTION
# Description

This PR brings in a route at PUT /rounds/nested/:id that expects a round and can handle an optional array of questions, each with arrays of answers.

Also includes a route at POST /games/nested that expects a game and can handle arrays of rounds with their questions and answers.  We may end up not using this one.

```
{
  "number": 1,
  "questions": [
    {
      "text": "test question",
      "question_type_id": 1,
      "category_id": 1,
      "difficulty": "easy",
      "answers": [
        {
          "text": "test answer",
          "is_correct": false
        }
      ]
    }
  ]
}

```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested via Insomnia and sending variations of potential requests to verify expected responses.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts