### PR TITLE
new users default to tier_id 1 (bronze)

### DIFF
--- a/data/migrations/20190424165604_create_tables.js
+++ b/data/migrations/20190424165604_create_tables.js
@@ -24,7 +24,8 @@ exports.up = function(knex) {
           .references("id")
           .inTable("tiers")
           .onDelete("CASCADE")
-          .onUpdate("CASCADE");
+          .onUpdate("CASCADE")
+          .defaultTo(1);
         tbl
           .string("email", 128)
           .notNullable()


### PR DESCRIPTION
# Description
This defaults new users to have a tier_id as 1 on the Users table. Previously new users had a null value for the tier_id.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A: After remigrating and seeding database, a new user that signs up starts with a tier_id of 1 and is able to upgrade that value by payment on the billing page
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts