### PR TITLE
backend checks if games/rounds limit has been met before creating new game/round in db

### DIFF
--- a/models/games.js
+++ b/models/games.js
@@ -1,5 +1,5 @@
-const db = require("../data/db");
-const Joi = require("@hapi/joi");
+const db = require('../data/db');
+const Joi = require('@hapi/joi');
 
 module.exports = {
   get,
@@ -11,31 +11,32 @@ module.exports = {
   validate,
   nestedInsert,
   nestedUpdate,
+  validateTier,
   findWithCounts,
   findByIdAndUserId,
   findByIdAndUserIdNormalized
 };
 
 function find() {
-  return db("games");
+  return db('games');
 }
 
 function findWithCounts() {
-  const subquery = db("questions")
-    .count("*")
-    .leftJoin("rounds", "rounds.id", "=", "questions.round_id")
-    .where("games.id", db.raw("??", ["rounds.game_id"]))
-    .as("num_questions");
+  const subquery = db('questions')
+    .count('*')
+    .leftJoin('rounds', 'rounds.id', '=', 'questions.round_id')
+    .where('games.id', db.raw('??', ['rounds.game_id']))
+    .as('num_questions');
 
   return find()
-    .select("games.*", subquery)
-    .count("rounds.id AS num_rounds")
-    .leftJoin("rounds", "rounds.game_id", "=", "games.id")
-    .groupBy("games.id");
+    .select('games.*', subquery)
+    .count('rounds.id AS num_rounds')
+    .leftJoin('rounds', 'rounds.game_id', '=', 'games.id')
+    .groupBy('games.id');
 }
 
 async function findByIdAndUserIdNormalized(id, user_id) {
-  const game = await db("games")
+  const game = await db('games')
     .where({ id })
     .where({ user_id })
     .first();
@@ -47,20 +48,18 @@ async function findByIdAndUserIdNormalized(id, user_id) {
 
   const result = game.id;
 
-  const rounds = await db("rounds").where({ game_id: game.id });
+  const rounds = await db('rounds').where({ game_id: game.id });
 
   game.rounds = rounds.map(r => r.id);
 
   entities.games = { [game.id]: game };
 
-  const questions = await db("questions")
-    .select(
-      "questions.*",
-    )
-    .whereIn("round_id", rounds.map(r => r.id));
+  const questions = await db('questions')
+    .select('questions.*')
+    .whereIn('round_id', rounds.map(r => r.id));
 
-  const answers = await db("answers").whereIn(
-    "question_id",
+  const answers = await db('answers').whereIn(
+    'question_id',
     questions.map(q => q.id)
   );
 
@@ -91,7 +90,7 @@ async function findByIdAndUserIdNormalized(id, user_id) {
 }
 
 async function findByIdAndUserId(id, user_id) {
-  const game = await db("games")
+  const game = await db('games')
     .where({ id })
     .where({ user_id })
     .first();
@@ -100,15 +99,15 @@ async function findByIdAndUserId(id, user_id) {
     return null;
   }
 
-  const rounds = await db("rounds").where({ game_id: game.id });
+  const rounds = await db('rounds').where({ game_id: game.id });
 
-  const questions = await db("questions").whereIn(
-    "round_id",
+  const questions = await db('questions').whereIn(
+    'round_id',
     rounds.map(r => r.id)
   );
 
-  const answers = await db("answers").whereIn(
-    "question_id",
+  const answers = await db('answers').whereIn(
+    'question_id',
     questions.map(q => q.id)
   );
 
@@ -141,19 +140,19 @@ async function getById(id) {
 }
 
 async function insert(game) {
-  return await db("games")
-    .insert(game, "id")
+  return await db('games')
+    .insert(game, 'id')
     .then(ids => getById(ids[0]));
 }
 
 async function update(id, changes) {
-  return await db("games")
+  return await db('games')
     .where({ id })
     .update(changes)
     .then(() => getById(id));
 }
 async function remove(id) {
-  return await db("games")
+  return await db('games')
     .where({ id })
     .del();
 }
@@ -182,10 +181,10 @@ async function nestedInsert({ rounds: newRounds, ...newGame }) {
 
   const createdRounds = await Promise.all(
     newRounds.map(({ questions: omit, ...r }) =>
-      db("rounds")
-        .insert({ game_id: createdGame.id, ...r }, "id")
+      db('rounds')
+        .insert({ game_id: createdGame.id, ...r }, 'id')
         .then(ids =>
-          db("rounds")
+          db('rounds')
             .where({ id: ids[0] })
             .first()
         )
@@ -216,10 +215,10 @@ async function nestedInsert({ rounds: newRounds, ...newGame }) {
   // batch insert those newQuestions, omit the answers here
   const createdQuestions = await Promise.all(
     newQuestions.map(({ answers: omit, ...q }) =>
-      db("questions")
-        .insert(q, "id")
+      db('questions')
+        .insert(q, 'id')
         .then(ids =>
-          db("questions")
+          db('questions')
             .where({ id: ids[0] })
             .first()
         )
@@ -243,7 +242,7 @@ async function nestedInsert({ rounds: newRounds, ...newGame }) {
   if (newAnswers.length === 0) {
     return createdGame.id;
   }
-  await db("answers").insert(newAnswers, "id");
+  await db('answers').insert(newAnswers, 'id');
 
   // return the id of the createdGame
   return createdGame.id;
@@ -253,7 +252,7 @@ async function nestedInsert({ rounds: newRounds, ...newGame }) {
 // and replaces them with new ones
 async function nestedUpdate(id, nestedGame) {
   const { rounds: newRounds, ...gameDetails } = nestedGame;
-  const dbGame = await db("games")
+  const dbGame = await db('games')
     .where({ id })
     .update(gameDetails)
     .then(() => getById(id));
@@ -263,17 +262,17 @@ async function nestedUpdate(id, nestedGame) {
   }
 
   // delete all of this game's rounds
-  await db("rounds")
+  await db('rounds')
     .where({ game_id: dbGame.id })
     .del();
 
   // create new rounds, questions, and answers
   const createdRounds = await Promise.all(
     newRounds.map(({ id: omitId, questions: omit, ...r }) =>
-      db("rounds")
-        .insert({ ...r, game_id: dbGame.id }, "id")
+      db('rounds')
+        .insert({ ...r, game_id: dbGame.id }, 'id')
         .then(ids =>
-          db("rounds")
+          db('rounds')
             .where({ id: ids[0] })
             .first()
         )
@@ -301,10 +300,10 @@ async function nestedUpdate(id, nestedGame) {
   // batch insert those newQuestions, omit the answers here
   const createdQuestions = await Promise.all(
     newQuestions.map(({ answers: omit, ...q }) =>
-      db("questions")
-        .insert(q, "id")
+      db('questions')
+        .insert(q, 'id')
         .then(ids =>
-          db("questions")
+          db('questions')
             .where({ id: ids[0] })
             .first()
         )
@@ -328,8 +327,30 @@ async function nestedUpdate(id, nestedGame) {
   if (newAnswers.length === 0) {
     return dbGame.id;
   }
-  await db("answers").insert(newAnswers, "id");
+  await db('answers').insert(newAnswers, 'id');
 
   // return the id of the updated Game
   return dbGame.id;
+}
+
+async function validateTier(user_id) {
+  //get game limit based on current tier
+  const { game_limit } = await db('users')
+    .join('tiers', 'users.tier_id', 'tiers.id')
+    .select('users.tier_id', 'users.id', 'tiers.game_limit')
+    .where({ 'users.id': user_id })
+    .first();
+
+  //get count of how many games have already been created
+  const { 'count(*)': gameCount } = await db('games')
+    .where({ user_id })
+    .count()
+    .first();
+
+  //compare gameCount vs game_limit and if it is the same, stop from creating new game
+  if (gameCount >= game_limit) {
+    return { status: 406 };
+  } else {
+    return { status: 200 };
+  }
 }

--- a/routes/rounds.js
+++ b/routes/rounds.js
@@ -88,6 +88,12 @@ router.post('/nested', validate(Rounds.schema, true), async (req, res) => {
   const { body: newRound } = req;
   const userId = req.user.dbInfo.id;
 
+  //check if user met round alottment for game based on tier
+  const roundNumber = await Rounds.validateTier(newRound.game_id, userId);
+  if (roundNumber.status === 406) {
+    return res.status(406).json({ error: 'round limit met for game' });
+  }
+
   const dbGame = await Games.find()
     .where({
       user_id: userId,


### PR DESCRIPTION
# Description

This PR brings in checks on the backend that will verify that a user has not already met their allotment of games or rounds dictated by their tier level. If they have met the limit a 406 error is sent back to the frontend when requesting to POST a new game/round to the /nested route. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A: Tested locally using postman and it has shown to work on all tier levels.
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts