### PR TITLE
Add category counts to game responses

### DIFF
--- a/models/games.js
+++ b/models/games.js
@@ -14,6 +14,7 @@ module.exports = {
   validateTier,
   findWithCounts,
   findByIdAndUserId,
+  findWithCategoryCounts,
   findByIdAndUserIdNormalized
 };
 
@@ -48,7 +49,22 @@ async function findByIdAndUserIdNormalized(id, user_id) {
 
   const result = game.id;
 
-  const rounds = await db('rounds').where({ game_id: game.id });
+  const dbRounds = await db('rounds').where({ game_id: game.id });
+
+  const category_counts = await db('rounds')
+    .count('categories.id as count')
+    .select('rounds.id', 'categories.name', 'categories.id as category_id')
+    .leftJoin('questions', 'questions.round_id', '=', 'rounds.id')
+    .leftJoin('categories', 'questions.category_id', '=', 'categories.id')
+    .groupBy('categories.id', 'rounds.game_id')
+    .whereIn('rounds.id', dbRounds.map(r => r.id));
+
+  const rounds = dbRounds.map(r => ({
+    ...r,
+    category_counts: category_counts
+      .filter(cc => cc.id === r.id)
+      .map(({ id: omit, ...cc }) => cc)
+  }));
 
   game.rounds = rounds.map(r => r.id);
 
@@ -353,4 +369,33 @@ async function validateTier(user_id) {
   } else {
     return { status: 200 };
   }
+}
+
+// find games, include their category counts
+async function findWithCategoryCounts(user_id) {
+  // get games with question and round counts
+  const games = await findWithCounts().where('games.user_id', user_id);
+
+  // get category_counts associated with these games
+  // grouping by multiple values in this way will
+  // return counts for all rows where game_id and categories.id
+  // are the same
+  const category_counts = await db('rounds')
+    .count('categories.id as count')
+    .select('rounds.game_id', 'categories.name', 'categories.id as category_id')
+    .leftJoin('questions', 'questions.round_id', '=', 'rounds.id')
+    .leftJoin('categories', 'questions.category_id', '=', 'categories.id')
+    .groupBy('categories.id', 'rounds.game_id')
+    .whereIn('rounds.game_id', games.map(g => g.id));
+
+  // add a category_counts array to the game object,
+  // omit the game_id on each category_count
+  const gamesWithCategoryCounts = games.map(g => ({
+    ...g,
+    category_counts: category_counts
+      .filter(cc => cc.game_id === g.id)
+      .map(({ game_id: omit, ...cc }) => cc)
+  }));
+
+  return gamesWithCategoryCounts;
 }

--- a/models/games.js
+++ b/models/games.js
@@ -56,7 +56,7 @@ async function findByIdAndUserIdNormalized(id, user_id) {
     .select('rounds.id', 'categories.name', 'categories.id as category_id')
     .leftJoin('questions', 'questions.round_id', '=', 'rounds.id')
     .leftJoin('categories', 'questions.category_id', '=', 'categories.id')
-    .groupBy('categories.id', 'rounds.game_id')
+    .groupBy('categories.id', 'rounds.id')
     .whereIn('rounds.id', dbRounds.map(r => r.id));
 
   const rounds = dbRounds.map(r => ({

--- a/routes/games.js
+++ b/routes/games.js
@@ -13,7 +13,8 @@ router.get('/', async (req, res) => {
 // get all user games
 router.get('/normalized', async (req, res) => {
   const user_id = req.user.dbInfo.id;
-  const games = await Games.findWithCounts().where('games.user_id', user_id);
+  const games = await Games.findWithCategoryCounts(user_id);
+  // const games = await Games.findWithCounts().where('games.user_id', user_id);
 
   const normalized = {
     result: games.map(g => g.id),


### PR DESCRIPTION
# Description

This PR adds category counts for `/games/normalized` and `/games/normalized/:id`.
Those will be used on the frontend.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested via Insomnia, ensuring category_counts is present on responses.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts