### PR TITLE
remove unique constraint for user nicknames

### DIFF
--- a/data/migrations/20190424165604_create_tables.js
+++ b/data/migrations/20190424165604_create_tables.js
@@ -30,9 +30,7 @@ exports.up = function(knex) {
           .string("email", 128)
           .notNullable()
           .unique();
-        tbl
-          .string("nickname", 128)
-          .unique();
+        tbl.string("nickname", 128)
         tbl.string("first_name", 128);
         tbl.string("last_name", 128);
         tbl.string("logo_id", 400);


### PR DESCRIPTION
This fixes a bug with account creation where users might have the same nickname.